### PR TITLE
Fix repo-name detection for repositories with "git" in the name

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
@@ -51,7 +51,7 @@ sub _create_release {
 
   my $releases = Pithub::Repos::Releases->new(
     user  => $identity{login} || $self->{username},
-    repo  => $self->_get_repo_name() || $self->{repo},
+    repo  => $self->{repo} || $self->_get_repo_name(),
     token => $identity{token},
   );
   die "Unable to instantiate Pithub::Repos::Releases" if (! defined $releases);
@@ -146,13 +146,25 @@ sub _get_repo_name {
     };
   };
 
-  #FIXME there must be a better way...
-  my $basename = uri_unescape( basename(URI->new( $url[0])->path));
-  $basename =~ s/.git//;
+  my $basename = $self->_repo_name_from_url($url[0]);
   $self->log("Release will be created using $basename");
 
   return $basename;
 
+}
+
+sub _repo_name_from_url {
+  my $self = shift;
+  my $url  = shift;
+
+  my $basename = uri_unescape( basename( URI->new($url)->path ) );
+  # Strip only a trailing ".git" suffix.  The old s/.git// matched any
+  # character followed by "git" anywhere in the string, so a repository
+  # whose name contains "git" (e.g. p5-git-libgit2) lost the wrong part
+  # and turned into p5-libgit2.
+  $basename =~ s/\.git$//;
+
+  return $basename;
 }
 
 sub _generate_release_notes {

--- a/t/repo-name-from-url.t
+++ b/t/repo-name-from-url.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+
+use_ok('Dist::Zilla::Plugin::GitHub::CreateRelease');
+
+my $class = 'Dist::Zilla::Plugin::GitHub::CreateRelease';
+
+# _repo_name_from_url only parses a string; it does not touch instance
+# state, so we can exercise it as a class method.
+my %cases = (
+  'git@github.com:Getty/p5-git-libgit2.git' => 'p5-git-libgit2',
+  'https://github.com/Getty/p5-git-libgit2.git' => 'p5-git-libgit2',
+  'git@github.com:timlegge/perl-Foo.git' => 'perl-Foo',
+  'https://github.com/timlegge/perl-Foo.git' => 'perl-Foo',
+  'git@github.com:owner/repo-without-suffix' => 'repo-without-suffix',
+  # a name that simply ends in "git" must keep its final character
+  'https://github.com/owner/digit.git' => 'digit',
+);
+
+for my $url (sort keys %cases) {
+  is($class->_repo_name_from_url($url), $cases{$url},
+    "repo name parsed from $url");
+}
+
+done_testing;


### PR DESCRIPTION
`_get_repo_name()` strips the trailing `.git` from the remote URL with `s/.git//` — an unescaped `.` and no end anchor. That matches the first `<any char>git` *anywhere* in the string, so a repository whose own name contains `git` loses the wrong piece:

```
p5-git-libgit2.git  ->  p5-libgit2.git  ->  Getty/p5-libgit2 (404)
```

The release then fails with `Unable to create GitHub release`.

**Two fixes:**

- Strip only a trailing `.git` (`s/\.git$//`). Parsing moved into a small `_repo_name_from_url()` helper so it's unit-testable without a real git checkout.
- Give the documented `repo` attribute precedence over auto-detection (`$self->{repo} || $self->_get_repo_name()`). The order was reversed, so an explicit `repo =` in `dist.ini` was ignored whenever a remote existed — making the bug impossible to work around.

Adds `t/repo-name-from-url.t` covering ssh/https URLs, names containing `git`, names ending in `git`, and names without a `.git` suffix.