### PR TITLE
Fix "uninitialized $prev" warning in ChangeLog release notes

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
@@ -186,19 +186,30 @@ sub _get_notes_from_changes {
   my $prev = $tags[1];
 
   my $file = read_text($self->{notes_file});
-  my @lines = split /\n/, $file;
-  my $print = 0;
-  my $notes = "";
-  foreach my $line (@lines) {
-    $print = 1 if ($line =~ /^$vers/);
-    $print = 0 if ($line =~ /^$prev/);
-    $notes .= $line . "\n" if $print;
-  }
+  my $notes = $self->_extract_changes($file, $vers, $prev);
+
   return $self->_as_code($notes) if (! $self->{add_checksum});
 
   $notes .= $self->_get_checksum($filename);
 
   return $self->_as_code($notes);
+}
+
+sub _extract_changes {
+  my ($self, $text, $vers, $prev) = @_;
+
+  my $print = 0;
+  my $notes = "";
+  for my $line (split /\n/, $text) {
+    # On the first release "git for-each-ref --count=2" returns a single
+    # tag, so $prev is undef; guard against it to avoid an uninitialized
+    # warning.  \Q...\E keeps version numbers (e.g. 0.003) from being
+    # treated as regex patterns.
+    $print = 1 if (defined $vers && $line =~ /^\Q$vers\E/);
+    $print = 0 if (defined $prev && $line =~ /^\Q$prev\E/);
+    $notes .= $line . "\n" if $print;
+  }
+  return $notes;
 }
 
 sub _get_notes_from_file {

--- a/t/extract-changes.t
+++ b/t/extract-changes.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test::More;
+
+use_ok('Dist::Zilla::Plugin::GitHub::CreateRelease');
+
+my $class = 'Dist::Zilla::Plugin::GitHub::CreateRelease';
+
+# _extract_changes only works on its arguments, so it can be exercised as
+# a class method without a Dist::Zilla instance or a git checkout.
+
+my $changes = <<'CHANGES';
+0.003     2026-05-27
+  - third release
+  - more stuff
+
+0.002     2026-05-01
+  - second release
+
+0.001     2026-04-01
+  - first release
+CHANGES
+
+# A normal release: notes run from the current tag up to (not including)
+# the previous tag.
+{
+  my $notes = $class->_extract_changes($changes, '0.003', '0.002');
+  like($notes,   qr/third release/,  'current section included');
+  unlike($notes, qr/second release/, 'previous section excluded');
+}
+
+# First release: for-each-ref --count=2 returns only one tag, so $prev is
+# undef.  This used to emit "Use of uninitialized value $prev in regexp".
+{
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+  my $notes = $class->_extract_changes($changes, '0.001', undef);
+
+  is_deeply(\@warnings, [], 'no warnings when previous tag is undef')
+    or diag "got: @warnings";
+  like($notes, qr/first release/, 'first release section captured');
+}
+
+# Version numbers must be matched literally, not as a regex (the "." in
+# 0.003 must not match an arbitrary character).
+{
+  my $tricky = "0x003  not a real version\n0.003  the real one\n";
+  my $notes  = $class->_extract_changes($tricky, '0.003', undef);
+  unlike($notes, qr/not a real version/, 'dot in version is matched literally');
+  like($notes,   qr/the real one/,       'literal version section captured');
+}
+
+done_testing;


### PR DESCRIPTION
When `notes_from = ChangeLog`, `_get_notes_from_changes()` reads the two most recent tags and prints the changelog section between them. On a dist's **first release**, `git for-each-ref --count=2` returns only one tag, so `$prev = $tags[1]` is undef and `/^$prev/` emits:

```
Use of uninitialized value $prev in regexp compilation
```

A second, latent issue: `$vers`/`$prev` were interpolated into the regex unquoted, so a version like `0.003` was treated as a pattern (the `.` matches any character).

The line-selection loop is moved into a small `_extract_changes()` helper (unit-testable without a git checkout) that guards both tags with `defined` and matches them literally via `\Q…\E`.

Adds `t/extract-changes.t` covering the normal two-tag case, the first-release (undef `$prev`) case asserting no warnings, and literal version matching.