### PR TITLE
Detect repository owner from the remote url, not just the repo name

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
@@ -22,6 +22,7 @@ use namespace::autoclean;
 
 has hash_alg => (is => 'ro', default => 'sha256');
 has repo => (is => 'ro');
+has repo_owner => (is => 'ro');
 has branch => (is => 'ro', default => 'main');
 has remote_name => (is => 'ro', default => 'origin');
 has title_template => (is => 'ro', default => 'Version RELEASE - TRIAL CPAN release');
@@ -49,7 +50,7 @@ sub _create_release {
   die "Unable to load github token from ~/.$org-identity or ~/.$org" if (! defined $identity{token});
 
   my $releases = Pithub::Repos::Releases->new(
-    user  => $identity{login} || $self->{username},
+    user  => $self->{repo_owner} || $self->_get_repo_owner() || $identity{login} || $self->{username},
     repo  => $self->{repo} || $self->_get_repo_name(),
     token => $identity{token},
   );
@@ -164,6 +165,42 @@ sub _repo_name_from_url {
   $basename =~ s/\.git$//;
 
   return $basename;
+}
+
+# The remote url's path holds both the owner and the repo name
+# (e.g. "pplu/kubernetes-rest.git"), but _repo_name_from_url only ever
+# kept the last segment. That silently discarded the owner, so a release
+# was always attempted under the github-identity login instead of the
+# repository's actual owner -- which fails whenever they differ, e.g. for
+# a repo that isn't owned by the account named in ~/.github-identity.
+sub _get_repo_owner {
+  my $self = shift;
+
+  my $setting = "remote." . $self->{remote_name} . ".url";
+  my $git = Git::Wrapper->new('./');
+  my @url;
+  try {
+    @url = $git->RUN('config', '--get', $setting);
+  }
+  catch {
+    return undef;
+  };
+
+  return $self->_repo_owner_from_url($url[0]);
+}
+
+sub _repo_owner_from_url {
+  my $self = shift;
+  my $url  = shift;
+
+  my $path = URI->new($url)->path;
+  $path =~ s{^/+}{};
+  my @parts = split m{/}, $path;
+  pop @parts;
+
+  return undef unless @parts;
+
+  return uri_unescape( join('/', @parts) );
 }
 
 sub _generate_release_notes {
@@ -357,6 +394,7 @@ In your F<dist.ini>:
 
  [GitHub::CreateRelease]
  repo = github_repo_name         ; optional
+ repo_owner = github_owner_name  ; optional
  branch = main                   ; default = main
  notes_as_code = 1               ; default = 1 (true)
  notes_from = SignReleaseNotes   ; default = SignReleaseNotes
@@ -445,6 +483,19 @@ cpan upload file.
 
 A string value that specifies the name of the github repository.  The module determines the
 name based on the remote url but this setting can override the name that is detected.
+
+=item repo_owner
+
+A string value that specifies the owner (user or organization) of the github repository.
+The module determines the owner based on the remote url (the same url used to detect
+C<repo>) but this setting can override the owner that is detected.
+
+If the owner cannot be determined from the remote url, the C<login> from the identity
+file (see B<GITHUB API AUTHENTICATION>) is used instead, which was the only behaviour
+before this attribute existed. That fallback only works when the identity's login is
+also the repository owner, so repositories owned by an account other than the one in
+the identity file (e.g. a repository you are a collaborator on) need either this
+attribute or a matching C<org_id> identity to create a release successfully.
 
 =item remote_name
 

--- a/t/repo-owner-from-url.t
+++ b/t/repo-owner-from-url.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+
+use_ok('Dist::Zilla::Plugin::GitHub::CreateRelease');
+
+my $class = 'Dist::Zilla::Plugin::GitHub::CreateRelease';
+
+# _repo_owner_from_url only parses a string; it does not touch instance
+# state, so we can exercise it as a class method.
+my %cases = (
+  'git@github.com:Getty/p5-git-libgit2.git'      => 'Getty',
+  'https://github.com/Getty/p5-git-libgit2.git'  => 'Getty',
+  # a repository whose owner differs from the releasing account's
+  # github-identity login -- this is the case that used to be silently
+  # discarded and made the release fail against the wrong owner.
+  'git@github.com:pplu/kubernetes-rest.git'      => 'pplu',
+  'https://github.com/pplu/kubernetes-rest.git'  => 'pplu',
+  'git@github.com:owner/repo-without-suffix'     => 'owner',
+);
+
+for my $url (sort keys %cases) {
+  is($class->_repo_owner_from_url($url), $cases{$url},
+    "repo owner parsed from $url");
+}
+
+is($class->_repo_owner_from_url('not-a-remote-url'), undef,
+  'no owner segment returns undef so callers can fall back');
+
+done_testing;


### PR DESCRIPTION
## Problem

`_repo_name_from_url` already parses the remote url's path (e.g. `pplu/kubernetes-rest.git`), but only keeps the last segment via `basename()` -- the owner part is discarded. `_create_release` then always uses the github-identity `login` as the API "user" (owner) parameter:

```perl
my $releases = Pithub::Repos::Releases->new(
  user  => $identity{login} || $self->{username},
  repo  => $self->{repo} || $self->_get_repo_name(),
  ...
);
```

That only works when the identity's login happens to be the actual repository owner. For a repository owned by someone else where you're a collaborator (e.g. a repo you help maintain but don't own), the release is attempted against the wrong `owner/repo` API path. That 404s, and thanks to the (separately reported) broken 404 check, surfaces only as the generic `Unable to create GitHub release`.

Concretely: releasing a repo at `git@github.com:pplu/kubernetes-rest.git` with a `~/.github-identity` login of `someoneelse` tries to create a release at `/repos/someoneelse/kubernetes-rest` instead of `/repos/pplu/kubernetes-rest`, even though `someoneelse`'s token has push access to the real repo.

## Fix

- Adds `_repo_owner_from_url` / `_get_repo_owner`, mirroring the existing `_repo_name_from_url` / `_get_repo_name` pair, to extract the owner segment from the same remote url.
- Adds a `repo_owner` attribute for explicit override, mirroring the existing `repo` attribute.
- `_create_release` now prefers the detected/overridden owner, falling back to `$identity{login}` (the previous, only, behaviour) when the owner can't be determined from the remote url -- so nothing changes for the common case where you own the repo yourself and the login already matches.
- Adds `t/repo-owner-from-url.t` covering both SSH and HTTPS remote url styles, including the `pplu/kubernetes-rest` case that motivated this.

`prove -l t/` passes (22 tests, 0 failures).

Related: #7 -- the broken 404 check referenced above, fixed separately.
