### PR TITLE
Fix 404/422 detection comparing HTTP::Response object to a string

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/CreateRelease.pm
@@ -66,8 +66,14 @@ sub _create_release {
       generate_release_notes => $self->{github_notes} ? \1 : \0,
     }
   );
-  die "Discussion category name is invalid" if  ($release->response eq '404');
-  die "Validation failed, or the endpoint has been spammed." if  ($release->response eq '422');
+  # ->response is the underlying HTTP::Response object, not a status code
+  # string, so comparing it with `eq '404'`/`eq '422'` never matches and
+  # these two checks never fired; every failure fell through to the
+  # generic "Unable to create GitHub release" below. ->code (as already
+  # used for the 403 check two lines down) delegates to the response's
+  # numeric status and is what these comparisons need.
+  die "Discussion category name is invalid" if  ($release->code eq '404');
+  die "Validation failed, or the endpoint has been spammed." if  ($release->code eq '422');
   die "login ($identity{login}) or token invalid for the specified repository ($releases->{repo})\n"
       if  ($release->code eq '403');
 


### PR DESCRIPTION
## Problem

`$release->response` returns the underlying `HTTP::Response` object (see `Pithub::Result`, where `code` is a delegated method on the `response` attribute: `handles => { code => 'code', ... }`). `_create_release` compares that object directly against string literals:

```perl
die "Discussion category name is invalid" if  ($release->response eq '404');
die "Validation failed, or the endpoint has been spammed." if  ($release->response eq '422');
die "login (...) or token invalid ..." if  ($release->code eq '403');
```

The first two comparisons stringify an `HTTP::Response` object and compare it to the literal string `"404"`/`"422"`, which never matches. So these two checks never fire, regardless of what actually happened. Every real failure -- a genuine 404, a 422, or anything else -- falls through past them to the generic:

```perl
if (! defined $release->content->{id}) {
  die "Unable to create GitHub release\n";
}
```

with no indication of what actually went wrong.

## Fix

Use `->code` for all three checks, consistently -- the same accessor the (working) 403 check two lines below already uses, which correctly delegates to the response's numeric HTTP status.

This is a one-line-per-check fix with no behaviour change beyond making the existing, intended error messages actually fire.

Related: #6 -- the wrong-owner bug whose 404 this check was supposed to surface.
